### PR TITLE
Fix field options not updatable anymore

### DIFF
--- a/packages/twenty-server/src/engine/metadata-modules/field-metadata/hooks/before-update-one-field.hook.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/field-metadata/hooks/before-update-one-field.hook.ts
@@ -75,7 +75,7 @@ export class BeforeUpdateOneField<T extends UpdateFieldInput>
     locale?: keyof typeof APP_LOCALES,
   ): UpdateOneInputType<T> {
     const update: StandardFieldUpdate = {};
-    const updatableFields = ['isActive', 'isLabelSyncedWithName'];
+    const updatableFields = ['isActive', 'isLabelSyncedWithName', 'options'];
     const overridableFields = ['label', 'icon', 'description'];
 
     const nonUpdatableFields = Object.keys(instance.update).filter(
@@ -109,11 +109,23 @@ export class BeforeUpdateOneField<T extends UpdateFieldInput>
     this.handleActiveField(instance, update);
     this.handleLabelSyncedWithNameField(instance, update);
     this.handleStandardOverrides(instance, fieldMetadata, update, locale);
+    this.handleOptionsField(instance, update);
 
     return {
       id: instance.id,
       update: update as T,
     };
+  }
+
+  private handleOptionsField(
+    instance: UpdateOneInputType<T>,
+    update: StandardFieldUpdate,
+  ): void {
+    if (!isDefined(instance.update.options)) {
+      return;
+    }
+
+    update.options = instance.update.options;
   }
 
   private handleActiveField(


### PR DESCRIPTION
# Task Description

Fix an issue where field options were no longer updatable in the system. The pull request addresses this functionality problem to restore the ability to update field options.