### PR TITLE
Fix filter button height 

### DIFF
--- a/packages/twenty-front/src/modules/views/components/ViewBarDetails.tsx
+++ b/packages/twenty-front/src/modules/views/components/ViewBarDetails.tsx
@@ -29,6 +29,7 @@ import { isViewBarExpandedComponentState } from '@/views/states/isViewBarExpande
 import { t } from '@lingui/core/macro';
 import { isNonEmptyArray } from '@sniptt/guards';
 import { isDefined } from 'twenty-shared/utils';
+import { LightButton } from 'twenty-ui';
 
 export type ViewBarDetailsProps = {
   hasFilterButton?: boolean;
@@ -63,18 +64,11 @@ const StyledChipcontainer = styled.div`
   z-index: 1;
 `;
 
-const StyledCancelButton = styled.button`
-  background-color: inherit;
-  border: none;
-  color: ${({ theme }) => theme.font.color.tertiary};
-  cursor: pointer;
-  font-weight: ${({ theme }) => theme.font.weight.medium};
-  user-select: none;
-  margin-right: ${({ theme }) => theme.spacing(2)};
-  &:hover {
-    background-color: ${({ theme }) => theme.background.tertiary};
-    border-radius: ${({ theme }) => theme.spacing(1)};
-  }
+const StyledActionButtonContainer = styled.div`
+  display: flex;
+  flex-direction: row;
+  gap: ${({ theme }) => theme.spacing(2)};
+  padding-top: ${({ theme }) => theme.spacing(1)};
 `;
 
 const StyledFilterContainer = styled.div`
@@ -257,15 +251,17 @@ export const ViewBarDetails = ({
           </StyledAddFilterContainer>
         )}
       </StyledFilterContainer>
-      {canResetView && (
-        <StyledCancelButton
-          data-testid="cancel-button"
-          onClick={handleCancelClick}
-        >
-          {t`Reset`}
-        </StyledCancelButton>
-      )}
-      {rightComponent}
+      <StyledActionButtonContainer>
+        {canResetView && (
+          <LightButton
+            data-testid="cancel-button"
+            accent="tertiary"
+            title={t`Reset`}
+            onClick={handleCancelClick}
+          />
+        )}
+        {rightComponent}
+      </StyledActionButtonContainer>
     </StyledBar>
   );
 };


### PR DESCRIPTION
# Task Description

Fix the filter reset button height in the UI by replacing the custom `StyledCancelButton` with the standard `LightButton` component to match the 24px height design specification in Figma. Wrap the button inside a `StyledChipcontainer` for layout consistency, fix indentation issues in the code, and remove duplicate CSS properties in the `StyledBar` component.