### PR TITLE
Fix sync-workspace log

### DIFF
--- a/packages/twenty-server/src/engine/workspace-manager/workspace-sync-metadata/commands/sync-workspace-metadata.command.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-sync-metadata/commands/sync-workspace-metadata.command.ts
@@ -62,8 +62,6 @@ export class SyncWorkspaceMetadataCommand extends ActiveOrSuspendedWorkspacesMig
       );
     }
 
-    this.logger.log(
-      `Finished synchronizing all active workspaces (${total} workspaces).`,
-    );
+    this.logger.log(`Finished synchronizing workspace.`);
   }
 }


### PR DESCRIPTION
# Task Description

Fix the log message in the sync-workspace functionality to make it more appropriate for logging each workspace synchronization, as the previous message no longer made sense when applied to multiple workspaces.