### PR TITLE
Hot fix for currentWorkspaceMember not found error on blocklist page

### DIFF
--- a/packages/twenty-front/src/modules/settings/accounts/components/SettingsAccountsBlocklistSection.tsx
+++ b/packages/twenty-front/src/modules/settings/accounts/components/SettingsAccountsBlocklistSection.tsx
@@ -10,23 +10,23 @@ import { useFindManyRecords } from '@/object-record/hooks/useFindManyRecords';
 import { SettingsAccountsBlocklistInput } from '@/settings/accounts/components/SettingsAccountsBlocklistInput';
 import { SettingsAccountsBlocklistTable } from '@/settings/accounts/components/SettingsAccountsBlocklistTable';
 import { useLingui } from '@lingui/react/macro';
+import { isDefined } from 'twenty-shared/utils';
 
 export const SettingsAccountsBlocklistSection = () => {
   const { t } = useLingui();
 
   const currentWorkspaceMember = useRecoilValue(currentWorkspaceMemberState);
 
-  if (!currentWorkspaceMember) {
-    throw new Error('No workspace member found.');
-  }
+  const currentWorkspaceMemberId = currentWorkspaceMember?.id ?? '';
 
   const { records: blocklist } = useFindManyRecords<BlocklistItem>({
     objectNameSingular: CoreObjectNameSingular.Blocklist,
     filter: {
       workspaceMemberId: {
-        in: [currentWorkspaceMember.id],
+        in: [currentWorkspaceMemberId],
       },
     },
+    skip: !isDefined(currentWorkspaceMember),
   });
 
   const { createOneRecord: createBlocklistItem } =


### PR DESCRIPTION
# Task Description

Fix an error occurring on the blocklist page where `currentWorkspaceMember` was not found. This issue was introduced in a previous pull request (#11325) and was causing errors tracked in Sentry. The fix handles the case when the workspace member data is temporarily missing or unavailable.