### PR TITLE
Twenty-website copy twenty-ui dockerfile

### DIFF
--- a/packages/twenty-docker/twenty-website/Dockerfile
+++ b/packages/twenty-docker/twenty-website/Dockerfile
@@ -8,6 +8,8 @@ COPY ./yarn.lock .
 COPY ./.yarnrc.yml .
 COPY ./.yarn/releases /app/.yarn/releases
 COPY ./tools/eslint-rules /app/tools/eslint-rules
+COPY ./packages/twenty-ui/package.json /app/packages/twenty-ui/
+COPY ./packages/twenty-shared/package.json /app/packages/twenty-shared/
 COPY ./packages/twenty-website/package.json /app/packages/twenty-website/package.json
 
 RUN yarn
@@ -17,6 +19,7 @@ ENV KEYSTATIC_GITHUB_CLIENT_SECRET="<fake build value>"
 ENV KEYSTATIC_SECRET="<fake build value>"
 ENV NEXT_PUBLIC_KEYSTATIC_GITHUB_APP_SLUG="<fake build value>"
 
+COPY ./packages/twenty-ui /app/packages/twenty-ui
 COPY ./packages/twenty-website /app/packages/twenty-website
 RUN npx nx build twenty-website
 


### PR DESCRIPTION
# Task Description

Update the Dockerfile for twenty-website to include the twenty-ui package during the build process by adding a COPY instruction for the twenty-ui directory. This fix ensures proper deployment by making the UI package available in the build stage, which is required due to workspace dependencies.