### PR TITLE
Fixed ViewBarDetails unnecessary padding-top

### DIFF
--- a/packages/twenty-front/src/modules/views/components/ViewBarDetails.tsx
+++ b/packages/twenty-front/src/modules/views/components/ViewBarDetails.tsx
@@ -60,7 +60,6 @@ const StyledChipcontainer = styled.div`
   flex-direction: row;
   overflow: scroll;
   gap: ${({ theme }) => theme.spacing(2)};
-  padding-top: ${({ theme }) => theme.spacing(1)};
   z-index: 1;
 `;
 
@@ -68,7 +67,6 @@ const StyledActionButtonContainer = styled.div`
   display: flex;
   flex-direction: row;
   gap: ${({ theme }) => theme.spacing(2)};
-  padding-top: ${({ theme }) => theme.spacing(1)};
 `;
 
 const StyledFilterContainer = styled.div`


### PR DESCRIPTION
# Task Description

Remove unnecessary padding-top from ViewBarDetails component to fix visual layout issue. The PR includes before and after screenshots showing the improvement in appearance, where the excessive top padding has been eliminated for a cleaner interface.