### PR TITLE
Switching plan overflows

### DIFF
--- a/packages/twenty-front/src/pages/onboarding/ChooseYourPlan.tsx
+++ b/packages/twenty-front/src/pages/onboarding/ChooseYourPlan.tsx
@@ -181,10 +181,6 @@ export const ChooseYourPlan = () => {
       ? BillingPlanKey.ENTERPRISE
       : BillingPlanKey.PRO;
 
-  const alternatePlanName = plans?.plans.find(
-    (plan) => plan.planKey === alternatePlan,
-  )?.baseProduct.name;
-
   return (
     <>
       {isDefined(baseProductPrice) && isDefined(billing) ? (
@@ -256,7 +252,7 @@ export const ChooseYourPlan = () => {
             </ActionLink>
             <span />
             <ActionLink onClick={handleSwitchPlan(alternatePlan)}>
-              <Trans>Switch to {alternatePlanName}</Trans>
+              <Trans>Switch Plan</Trans>
             </ActionLink>
             <span />
             <ActionLink href={CAL_LINK} target="_blank" rel="noreferrer">


### PR DESCRIPTION
# Task Description

Fix modal overflow issue by simplifying the switch plan button in the onboarding page. Replace the dynamic button label (which included the alternate plan name) with a static "Switch Plan" text. Also clean up code by reordering imports and removing useless code. This is a temporary solution until a better version with Stripe pricing page is implemented next week.