### PR TITLE
remove billing stripe plan product id from env

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/environment/environment-variables.ts
+++ b/packages/twenty-server/src/engine/core-modules/environment/environment-variables.ts
@@ -528,15 +528,6 @@ export class EnvironmentVariables {
   BILLING_STRIPE_WEBHOOK_SECRET: string;
 
   @EnvironmentVariablesMetadata({
-    group: EnvironmentVariablesGroup.BillingConfig,
-    sensitive: true,
-    description: 'Base plan product ID for Stripe billing',
-  })
-  @IsString()
-  @ValidateIf((env) => env.IS_BILLING_ENABLED === true)
-  BILLING_STRIPE_BASE_PLAN_PRODUCT_ID: string;
-
-  @EnvironmentVariablesMetadata({
     group: EnvironmentVariablesGroup.ServerConfig,
     description: 'Url for the frontend application',
   })


### PR DESCRIPTION
# Task Description

Remove the billing Stripe plan product ID from the environment variables, as specified in issue #661. This change simplifies the configuration by eliminating the need to store this Stripe product ID in the environment settings.