### PR TITLE
Update CONTRIBUTING.md

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -13,14 +13,10 @@ Good first issues are a great way to start contributing and get familiar with th
 
 ## Issue assignment
 
-Having multiple contributors address the same issue can cause frustration.
-
 To avoid conflicts, we follow these guidelines:
-1. If a core team member assigned you the issue within the last three days, your PR takes priority.
-2. Otherwise, the first submitted PR is prioritized.
-3. For "size: long" PRs, the assignment period extends to one week.
 
-Please ensure you're assigned to an issue before starting work.
+1. For `Good First Issue` and `Experienced Contributor` issues without `size: long` labels, we'll merge the first PRs that meet our [code quality standards](https://twenty.com/developers). **We don't assign contributors to these issues**. For `priority: high` issues, our core team will step in within days if no adequate contributions are received.
+2. For `size: long` Issues, assigned contributors have one week to submit their first draft PR.
 
 ## How to Contribute
 


### PR DESCRIPTION
# Task Description

Update the issue assignment policy in CONTRIBUTING.md to prioritize merging qualified PRs over assigning issues. The changes specifically:

1. Clarify that for "Good First Issue" and "Experienced Contributor" issues without "size: long" labels, the team will merge the first PRs that meet code quality standards rather than assigning contributors
2. Fix a minor text duplication in a link reference
3. Remove second-person references ("you") from the document for more consistent tone
4. Add information about a one-week submission window for "size: long" issues

The update aims to streamline the contribution process and set clearer expectations for contributors.