### PR TITLE
Avoid settings object cover image to be reduced on scroll

### DIFF
--- a/packages/twenty-front/src/modules/settings/data-model/objects/components/SettingsObjectCoverImage.tsx
+++ b/packages/twenty-front/src/modules/settings/data-model/objects/components/SettingsObjectCoverImage.tsx
@@ -2,11 +2,11 @@ import styled from '@emotion/styled';
 
 import { SettingsPath } from '@/types/SettingsPath';
 import { useLingui } from '@lingui/react/macro';
+import { IconEye } from 'twenty-ui/display';
+import { FloatingButton } from 'twenty-ui/input';
+import { Card } from 'twenty-ui/layout';
 import DarkCoverImage from '../../assets/cover-dark.png';
 import LightCoverImage from '../../assets/cover-light.png';
-import { Card } from 'twenty-ui/layout';
-import { FloatingButton } from 'twenty-ui/input';
-import { IconEye } from 'twenty-ui/display';
 
 const StyledCoverImageContainer = styled(Card)`
   align-items: center;
@@ -18,7 +18,7 @@ const StyledCoverImageContainer = styled(Card)`
   border-radius: ${({ theme }) => theme.border.radius.md};
   box-sizing: border-box;
   display: flex;
-  height: 153px;
+  min-height: 153px;
   justify-content: center;
   position: relative;
   margin-bottom: ${({ theme }) => theme.spacing(8)};


### PR DESCRIPTION
# Task Description

Fix an issue where the settings object cover image was being reduced on scroll by implementing a min-height property instead of a fixed height, ensuring the image maintains proper dimensions during scrolling.