### PR TITLE
Center empty state on record table

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-table/components/RecordTableWithWrappers.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-table/components/RecordTableWithWrappers.tsx
@@ -22,6 +22,7 @@ const StyledTableContainer = styled.div`
   flex-direction: column;
   position: relative;
   width: 100%;
+  height: 100%;
 `;
 
 type RecordTableWithWrappersProps = {


### PR DESCRIPTION
# Task Description

Center the empty state display on the record table to improve visual alignment and user experience.