### PR TITLE
Improving empty filter chip UI

### DIFF
--- a/packages/twenty-front/src/modules/views/components/EditableFilterChip.tsx
+++ b/packages/twenty-front/src/modules/views/components/EditableFilterChip.tsx
@@ -2,6 +2,7 @@ import { useFieldMetadataItemById } from '@/object-metadata/hooks/useFieldMetada
 import { getOperandLabelShort } from '@/object-record/object-filter-dropdown/utils/getOperandLabel';
 import { RecordFilter } from '@/object-record/record-filter/types/RecordFilter';
 import { SortOrFilterChip } from '@/views/components/SortOrFilterChip';
+import { isNonEmptyString } from '@sniptt/guards';
 import { useIcons } from 'twenty-ui/display';
 
 type EditableFilterChipProps = {
@@ -21,11 +22,15 @@ export const EditableFilterChip = ({
 
   const FieldMetadataItemIcon = getIcon(fieldMetadataItem.icon);
 
+  const operandLabelShort = getOperandLabelShort(viewFilter.operand);
+
+  const labelKey = `${viewFilter.label}${isNonEmptyString(viewFilter.value) ? operandLabelShort : ''}`;
+
   return (
     <SortOrFilterChip
       key={viewFilter.id}
       testId={viewFilter.id}
-      labelKey={`${viewFilter.label}${getOperandLabelShort(viewFilter.operand)}`}
+      labelKey={labelKey}
       labelValue={viewFilter.displayValue}
       Icon={FieldMetadataItemIcon}
       onRemove={onRemove}


### PR DESCRIPTION
# Task Description

Remove the colon character (":") from filter chips when the filter value is empty, improving the UI appearance. This change addresses an issue where the colon was displayed even when no filter value was present. The PR does not modify the existing behavior where filter chips are automatically removed when closing the filter value dropdown with an empty value, as this was already the default functionality.