### PR TITLE
Refactor webhook event name generation in OpenApiService

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/open-api/open-api.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/open-api/open-api.service.ts
@@ -82,18 +82,24 @@ export class OpenApiService {
 
     schema.webhooks = objectMetadataItems.reduce(
       (paths, item) => {
-        paths[`Create ${item.nameSingular}`] = computeWebhooks(
-          DatabaseEventAction.CREATED,
-          item,
-        );
-        paths[`Update ${item.nameSingular}`] = computeWebhooks(
-          DatabaseEventAction.UPDATED,
-          item,
-        );
-        paths[`Delete ${item.nameSingular}`] = computeWebhooks(
-          DatabaseEventAction.DELETED,
-          item,
-        );
+        paths[
+          this.createWebhookEventName(
+            DatabaseEventAction.CREATED,
+            item.nameSingular,
+          )
+        ] = computeWebhooks(DatabaseEventAction.CREATED, item);
+        paths[
+          this.createWebhookEventName(
+            DatabaseEventAction.UPDATED,
+            item.nameSingular,
+          )
+        ] = computeWebhooks(DatabaseEventAction.UPDATED, item);
+        paths[
+          this.createWebhookEventName(
+            DatabaseEventAction.DELETED,
+            item.nameSingular,
+          )
+        ] = computeWebhooks(DatabaseEventAction.DELETED, item);
 
         return paths;
       },
@@ -225,5 +231,12 @@ export class OpenApiService {
     };
 
     return schema;
+  }
+
+  createWebhookEventName(
+    action: DatabaseEventAction,
+    objectName: string,
+  ): string {
+    return `${capitalize(objectName)} ${capitalize(action)}`;
   }
 }


### PR DESCRIPTION
# Task Description

Refactor the webhook event name generation functionality in the OpenApiService to fix issue #11589. The refactoring aims to improve how webhook event names are generated, as indicated by the pull request title and the referenced issue. The change appears to be a code improvement rather than adding new functionality.