### PR TITLE
Fix tab icon alignment issue

### DIFF
--- a/packages/twenty-front/src/modules/ui/layout/tab/components/Tab.tsx
+++ b/packages/twenty-front/src/modules/ui/layout/tab/components/Tab.tsx
@@ -4,8 +4,8 @@ import { useTheme } from '@emotion/react';
 import styled from '@emotion/styled';
 import { ReactElement } from 'react';
 import { Link } from 'react-router-dom';
-import { Avatar, IconComponent } from 'twenty-ui/display';
 import { Pill } from 'twenty-ui/components';
+import { Avatar, IconComponent } from 'twenty-ui/display';
 
 type TabProps = {
   id: string;
@@ -69,6 +69,9 @@ const StyledHover = styled.span`
 
 const StyledIconContainer = styled.div`
   flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 `;
 
 export const Tab = ({


### PR DESCRIPTION
# Task Description

Fix the alignment issue with tab icons in the UI. The PR corrects the positioning of tab icons that were previously misaligned, as shown in the before/after screenshots. The changes also include removing an unwanted debug class name that was likely contributing to the alignment problem.