### PR TITLE
fix: re-init subscription items when user ends his trial period

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/billing/services/billing-subscription.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/billing/services/billing-subscription.service.ts
@@ -45,6 +45,8 @@ export class BillingSubscriptionService {
     private readonly stripeCustomerService: StripeCustomerService,
     private readonly twentyConfigService: TwentyConfigService,
     private readonly stripeSubscriptionItemService: StripeSubscriptionItemService,
+    @InjectRepository(BillingSubscriptionItem, 'core')
+    private readonly billingSubscriptionItemRepository: Repository<BillingSubscriptionItem>,
   ) {}
 
   async getCurrentBillingSubscriptionOrThrow(criteria: {
@@ -239,6 +241,11 @@ export class BillingSubscriptionService {
           trial_end: 'now',
         },
       );
+
+    await this.billingSubscriptionItemRepository.update(
+      { stripeSubscriptionId: updatedSubscription.id },
+      { hasReachedCurrentPeriodCap: false },
+    );
 
     return {
       status: getSubscriptionStatus(updatedSubscription.status),


### PR DESCRIPTION
# Task Description

Re-initialize subscription item when a user ends their trial period.

The pull request fixes an issue related to subscription handling by ensuring that the subscription item is properly re-initialized after a user's trial period ends.