### PR TITLE
Set the page hotkey scope only once

### DIFF
--- a/packages/twenty-front/src/hooks/useIsMatchingLocation.ts
+++ b/packages/twenty-front/src/hooks/useIsMatchingLocation.ts
@@ -2,27 +2,31 @@ import { matchPath, useLocation } from 'react-router-dom';
 
 import { AppBasePath } from '@/types/AppBasePath';
 import { isNonEmptyString } from '@sniptt/guards';
+import { useCallback } from 'react';
 import { isDefined } from 'twenty-shared/utils';
+
+const addTrailingSlash = (path: string) =>
+  path.endsWith('/') ? path : path + '/';
+
+const getConstructedPath = (path: string, basePath?: AppBasePath) => {
+  if (!isNonEmptyString(basePath)) return path;
+
+  return addTrailingSlash(basePath) + path;
+};
 
 export const useIsMatchingLocation = () => {
   const location = useLocation();
 
-  const addTrailingSlash = (path: string) =>
-    path.endsWith('/') ? path : path + '/';
-
-  const getConstructedPath = (path: string, basePath?: AppBasePath) => {
-    if (!isNonEmptyString(basePath)) return path;
-
-    return addTrailingSlash(basePath) + path;
-  };
-
-  const isMatchingLocation = (path: string, basePath?: AppBasePath) => {
-    const match = matchPath(
-      getConstructedPath(path, basePath),
-      location.pathname,
-    );
-    return isDefined(match);
-  };
+  const isMatchingLocation = useCallback(
+    (path: string, basePath?: AppBasePath) => {
+      const match = matchPath(
+        getConstructedPath(path, basePath),
+        location.pathname,
+      );
+      return isDefined(match);
+    },
+    [location.pathname],
+  );
 
   return {
     isMatchingLocation,


### PR DESCRIPTION
# Task Description

Optimize the `PageChangeEffect` component by fixing the `useEffect` that sets the page's hotkey scope to run only once when the location changes, rather than 4-5 times. This was accomplished by memoizing the `isMatchingLocation` function to prevent unnecessary re-renders caused by unstable dependencies.