### PR TITLE
fix billing command - add workflow subscription item 

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/billing/commands/billing-add-workflow-subscription-item.command.ts
+++ b/packages/twenty-server/src/engine/core-modules/billing/commands/billing-add-workflow-subscription-item.command.ts
@@ -81,6 +81,17 @@ export class BillingAddWorkflowSubscriptionItemCommand extends ActiveOrSuspended
     }
 
     if (!options.dryRun) {
+      await this.stripeSubscriptionService.updateSubscription(
+        subscription.stripeSubscriptionId,
+        {
+          trial_settings: {
+            end_behavior: {
+              missing_payment_method: 'create_invoice',
+            },
+          },
+        },
+      );
+
       await this.stripeSubscriptionItemService.createSubscriptionItem(
         subscription.stripeSubscriptionId,
         associatedWorkflowMeteredPrice.stripePriceId,


### PR DESCRIPTION
# Task Description

Update the billing command to add workflow subscription items for users with trialing or paused subscriptions. The changes include:

1. Moving the billing threshold update inside the dryRun check to prevent modifications during testing
2. Setting trial end behavior to 'create_invoice' when payment methods are missing
3. Adding functionality to create workflow subscription items for the appropriate Stripe subscriptions
4. Improving the sequence of operations to ensure proper handling of trial settings before subscription item creation
5. Fixing log message placement to accurately reflect successful completion of operations