### PR TITLE
Fix mismatching stripe subscription metadata plan/planKey

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/billing/utils/get-plan-key-from-subscription.util.ts
+++ b/packages/twenty-server/src/engine/core-modules/billing/utils/get-plan-key-from-subscription.util.ts
@@ -4,9 +4,9 @@ import { BillingPlanKey } from 'src/engine/core-modules/billing/enums/billing-pl
 export const getPlanKeyFromSubscription = (
   subscription: BillingSubscription,
 ): BillingPlanKey => {
-  const planKey = subscription.metadata?.planKey;
+  const plan = subscription.metadata?.plan; //To do : #867  Naming issue decide if we should rename stripe product metadata planKey to plan (+ productKey to product) OR at session checkout creating subscription with metadata planKey (and not plan)
 
-  switch (planKey) {
+  switch (plan) {
     case 'PRO':
       return BillingPlanKey.PRO;
     case 'ENTERPRISE':


### PR DESCRIPTION
# Task Description

Fix inconsistency in Stripe subscription metadata where the plan and planKey values were mismatched. This addresses an existing issue tracked in the core team issues repository (#867).