### PR TITLE
Fix filter button height 

### DIFF
--- a/packages/twenty-front/src/modules/views/components/ViewBarDetails.tsx
+++ b/packages/twenty-front/src/modules/views/components/ViewBarDetails.tsx
@@ -71,6 +71,7 @@ const StyledCancelButton = styled.button`
   font-weight: ${({ theme }) => theme.font.weight.medium};
   user-select: none;
   margin-right: ${({ theme }) => theme.spacing(2)};
+  height: 24px;
   &:hover {
     background-color: ${({ theme }) => theme.background.tertiary};
     border-radius: ${({ theme }) => theme.spacing(1)};


### PR DESCRIPTION
# Task Description

Fix the filter reset button height in the UI by replacing the custom `StyledCancelButton` with the standard `LightButton` component to match the 24px height design specification in Figma. Wrap the button inside a `StyledChipcontainer` for layout consistency, fix indentation issues in the code, and remove duplicate CSS properties in the `StyledBar` component.