### PR TITLE
chore(ci): extend timeout for Danger JS job

### DIFF
--- a/.github/workflows/ci-utils.yaml
+++ b/.github/workflows/ci-utils.yaml
@@ -21,7 +21,7 @@ concurrency:
 
 jobs:
   danger-js:
-    timeout-minutes: 3
+    timeout-minutes: 5
     runs-on: ubuntu-latest
     if: github.event.action != 'closed'
     steps:


### PR DESCRIPTION
# Task Description

Extend the timeout for the Danger JS job in CI from 3 to 5 minutes to prevent premature failures during slower runs, ensuring more reliable workflow execution.