### PR TITLE
fix settings container vertical scroll position

### DIFF
--- a/packages/twenty-front/src/modules/ui/utilities/scroll/components/ScrollWrapper.tsx
+++ b/packages/twenty-front/src/modules/ui/utilities/scroll/components/ScrollWrapper.tsx
@@ -16,7 +16,6 @@ const StyledScrollWrapper = styled.div`
   }
   overflow-x: hidden;
   overflow-y: hidden;
-  display: flex;
   width: 100%;
   height: 100%;
 `;


### PR DESCRIPTION
# Task Description

Fix the settings container vertical scroll position by removing unnecessary flex styling. The change ensures proper scrolling behavior in the settings container, as demonstrated in the before and after screenshots. The PR author confirmed that all scrolls are working correctly after the change, though requested a final verification from a colleague.