### PR TITLE
Fix PageHeaderToggleCommandMenuButton

### DIFF
--- a/packages/twenty-front/src/modules/ui/layout/page-header/components/PageHeaderToggleCommandMenuButton.tsx
+++ b/packages/twenty-front/src/modules/ui/layout/page-header/components/PageHeaderToggleCommandMenuButton.tsx
@@ -118,31 +118,30 @@ export const PageHeaderToggleCommandMenuButton = () => {
   const theme = useTheme();
 
   return (
-    <div>
-      <StyledButtonWrapper>
-        <div id="toggle-command-menu-button">
-          <AnimatedButton
-            animatedSvg={
-              <AnimatedIcon isCommandMenuOpened={isCommandMenuOpened} />
-            }
-            className="page-header-command-menu-button"
-            dataTestId="page-header-command-menu-button"
-            size={isMobile ? 'medium' : 'small'}
-            variant="secondary"
-            accent="default"
-            hotkeys={[getOsControlSymbol(), 'K']}
-            ariaLabel={ariaLabel}
-            onClick={toggleCommandMenu}
-            animate={{
-              rotate: isCommandMenuOpened ? 90 : 0,
-            }}
-            transition={{
-              duration: theme.animation.duration.normal,
-              ease: 'easeInOut',
-            }}
-          />
-        </div>
-      </StyledButtonWrapper>
+    <StyledButtonWrapper>
+      <div id="toggle-command-menu-button">
+        <AnimatedButton
+          animatedSvg={
+            <AnimatedIcon isCommandMenuOpened={isCommandMenuOpened} />
+          }
+          className="page-header-command-menu-button"
+          dataTestId="page-header-command-menu-button"
+          size={isMobile ? 'medium' : 'small'}
+          variant="secondary"
+          accent="default"
+          hotkeys={[getOsControlSymbol(), 'K']}
+          ariaLabel={ariaLabel}
+          onClick={toggleCommandMenu}
+          animate={{
+            rotate: isCommandMenuOpened ? 90 : 0,
+          }}
+          transition={{
+            duration: theme.animation.duration.normal,
+            ease: 'easeInOut',
+          }}
+        />
+      </div>
+
       <StyledTooltipWrapper>
         <AppTooltip
           anchorSelect="#toggle-command-menu-button"
@@ -153,6 +152,6 @@ export const PageHeaderToggleCommandMenuButton = () => {
           noArrow
         />
       </StyledTooltipWrapper>
-    </div>
+    </StyledButtonWrapper>
   );
 };


### PR DESCRIPTION
# Task Description

Fix a bug in the PageHeaderToggleCommandMenuButton component that was introduced in a previous pull request (#11470). The fix restores proper functionality to the command menu button in the page header, as demonstrated by the before/after screenshots in the PR description.