### PR TITLE
Fix wrong filter for get requests

### DIFF
--- a/packages/twenty-server/src/engine/api/rest/core/controllers/rest-api-core.controller.ts
+++ b/packages/twenty-server/src/engine/api/rest/core/controllers/rest-api-core.controller.ts
@@ -37,7 +37,6 @@ export class RestApiCoreController {
   }
 
   @Get()
-  @UseFilters(RestApiExceptionFilter)
   async handleApiGet(@Req() request: Request, @Res() res: Response) {
     const result = await this.restApiCoreService.get(request);
 


### PR DESCRIPTION
# Task Description

Fix incorrect exception filter for GET API requests by removing `@UseFilters(RestApiExceptionFilter)` from the `handleApiGet` method in the REST API controller, allowing GET requests to use NestJS's default exception handling instead of the custom filter that was causing issues. This change improves the API playground testing experience by fixing error handling for GET requests.