### PR TITLE
Fix boolean default value update not updating psql default value when false

### DIFF
--- a/packages/twenty-server/src/engine/metadata-modules/field-metadata/field-metadata.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/field-metadata/field-metadata.service.ts
@@ -255,9 +255,9 @@ export class FieldMetadataService extends TypeOrmQueryService<FieldMetadataEntit
       }
 
       if (
-        fieldMetadataInput.name ||
-        updatableFieldInput.options ||
-        updatableFieldInput.defaultValue
+        isDefined(fieldMetadataInput.name) ||
+        isDefined(updatableFieldInput.options) ||
+        isDefined(updatableFieldInput.defaultValue)
       ) {
         await this.workspaceMigrationService.createCustomMigration(
           generateMigrationName(`update-${updatedFieldMetadata.name}`),


### PR DESCRIPTION
# Task Description

Fix a bug where updating a boolean field's default value to `false` was not properly reflected in PostgreSQL database migrations. The issue occurred because the condition `if (updatableFieldInput.defaultValue)` would evaluate to false when the default value was explicitly set to `false`, causing the migration code to be skipped for this case.