### PR TITLE
revert: transform -> marginLeft in DefaultLayout motion div

### DIFF
--- a/packages/twenty-front/src/modules/ui/layout/page/components/DefaultLayout.tsx
+++ b/packages/twenty-front/src/modules/ui/layout/page/components/DefaultLayout.tsx
@@ -80,16 +80,14 @@ export const DefaultLayout = () => {
         <AppErrorBoundary FallbackComponent={AppFullScreenErrorFallback}>
           <StyledPageContainer
             animate={{
-              transform:
+              marginLeft:
                 isSettingsPage && !isMobile && !useShowFullScreen
-                  ? `translateX(${
-                      (windowsWidth -
-                        (OBJECT_SETTINGS_WIDTH +
-                          NAV_DRAWER_WIDTHS.menu.desktop.expanded +
-                          76)) /
-                      2
-                    }px)`
-                  : 'translateX(0)',
+                  ? (windowsWidth -
+                      (OBJECT_SETTINGS_WIDTH +
+                        NAV_DRAWER_WIDTHS.menu.desktop.expanded +
+                        76)) /
+                    2
+                  : 0,
             }}
             transition={{
               duration: theme.animation.duration.normal,


### PR DESCRIPTION
# Task Description

Revert a previous change that used `transform` instead of `marginLeft` in DefaultLayout motion div. The original change was intended to create smooth transitions between fullscreen and normal screens with drawer, but it caused significant layout regressions on the settings page. This reversion restores the use of `marginLeft` to fix these layout issues, with the understanding that transitions can be improved separately in the future.